### PR TITLE
Add JWT-protected forms schema endpoint

### DIFF
--- a/onsite-lite-api/routes/api/forms/structure.js
+++ b/onsite-lite-api/routes/api/forms/structure.js
@@ -1,7 +1,55 @@
 'use strict'
 
 module.exports = async function (fastify, opts) {
-  fastify.get('/structure', { preValidation: [fastify.authenticate] }, async function (request, reply) {
-    return { message: 'OK' }
-  })
+  fastify.get(
+    '/structure',
+    { preValidation: [fastify.authenticate] },
+    async function (request, reply) {
+      const claim =
+        request.user[
+          'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'
+        ]
+
+      const roles = Array.isArray(claim)
+        ? claim
+        : claim
+          ? [claim]
+          : []
+
+      if (roles.length === 0) {
+        return []
+      }
+
+      const params = {}
+      const placeholders = roles
+        .map((role, idx) => {
+          const key = `role${idx}`
+          params[key] = role
+          return `@${key}`
+        })
+        .join(', ')
+
+      const sql = `
+        SELECT ft.Id AS formTypeId,
+               ft.Name AS name,
+               fs.SchemaJson AS schemaJson,
+               fs.Version AS version
+        FROM FormType ft
+        JOIN FormSchema fs ON fs.FormTypeId = ft.Id
+        WHERE ft.Name IN (${placeholders})
+          AND fs.Version = (
+            SELECT MAX(Version) FROM FormSchema WHERE FormTypeId = ft.Id
+          )
+      `
+
+      const result = await fastify.db.query(sql, params)
+
+      return result.recordset.map((row) => ({
+        formTypeId: row.formTypeId,
+        name: row.name,
+        schema: JSON.parse(row.schemaJson),
+        version: row.version
+      }))
+    }
+  )
 }

--- a/onsite-lite-api/test/routes/forms-structure.test.js
+++ b/onsite-lite-api/test/routes/forms-structure.test.js
@@ -12,15 +12,51 @@ test('structure requires auth', async (t) => {
   assert.equal(res.statusCode, 401)
 })
 
-test('structure returns ok with jwt', async (t) => {
+test('structure rejects invalid token', async (t) => {
   const app = await build(t)
-  const token = app.jwt.sign({ id: 1 })
   const res = await app.inject({
     url: path,
-    headers: {
-      authorization: `Bearer ${token}`
-    }
+    headers: { authorization: 'Bearer invalid' }
   })
+  assert.equal(res.statusCode, 401)
+})
+
+test('structure returns schemas for roles', async (t) => {
+  const app = await build(t)
+
+  // stub database query
+  app.db.query = async () => {
+    return {
+      recordset: [
+        {
+          formTypeId: 1,
+          name: 'Magenta EICR (V2)',
+          schemaJson: '{"foo": "bar"}',
+          version: 3
+        }
+      ]
+    }
+  }
+
+  const token = app.jwt.sign({
+    id: 1,
+    'http://schemas.microsoft.com/ws/2008/06/identity/claims/role': [
+      'Magenta EICR (V2)'
+    ]
+  })
+
+  const res = await app.inject({
+    url: path,
+    headers: { authorization: `Bearer ${token}` }
+  })
+
   assert.equal(res.statusCode, 200)
-  assert.deepStrictEqual(JSON.parse(res.payload), { message: 'OK' })
+  assert.deepStrictEqual(JSON.parse(res.payload), [
+    {
+      formTypeId: 1,
+      name: 'Magenta EICR (V2)',
+      schema: { foo: 'bar' },
+      version: 3
+    }
+  ])
 })


### PR DESCRIPTION
## Summary
- enhance `/api/forms/structure` to return schemas based on JWT roles
- update corresponding tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887c647cbd88328951c73183acd8719