### PR TITLE
feat(forms): add create endpoint

### DIFF
--- a/onsite-lite-api/repositories/formRepository.js
+++ b/onsite-lite-api/repositories/formRepository.js
@@ -29,4 +29,40 @@ async function getLatestSchemasByRoles(roles, database = db) {
   return result.recordset
 }
 
-module.exports = { getLatestSchemasByRoles }
+async function createFormTypeAndSchema (name, schema, database = db) {
+  // check if form type exists
+  const typeResult = await database.query(
+    'SELECT Id FROM FormType WHERE Name = @name',
+    { name }
+  )
+
+  let formTypeId
+  let version
+
+  if (typeResult.recordset.length === 0) {
+    // insert new form type and start at version 1
+    const insertType = await database.query(
+      'INSERT INTO FormType (Name) OUTPUT INSERTED.Id VALUES (@name)',
+      { name }
+    )
+    formTypeId = insertType.recordset[0].Id
+    version = 1
+  } else {
+    formTypeId = typeResult.recordset[0].Id
+    const versionResult = await database.query(
+      'SELECT MAX(Version) AS maxVersion FROM FormSchema WHERE FormTypeId = @formTypeId',
+      { formTypeId }
+    )
+    const maxVersion = versionResult.recordset[0].maxVersion || 0
+    version = maxVersion + 1
+  }
+
+  await database.query(
+    'INSERT INTO FormSchema (FormTypeId, SchemaJson, Version) VALUES (@formTypeId, @schemaJson, @version)',
+    { formTypeId, schemaJson: JSON.stringify(schema), version }
+  )
+
+  return { formTypeId, version }
+}
+
+module.exports = { getLatestSchemasByRoles, createFormTypeAndSchema }

--- a/onsite-lite-api/routes/api/forms.js
+++ b/onsite-lite-api/routes/api/forms.js
@@ -9,4 +9,11 @@ module.exports = async function (fastify, opts) {
     const schemas = await formService.getLatestSchemasByRoles(roles, fastify.db)
     return schemas
   })
+
+  fastify.post('/forms', { preValidation: [fastify.authenticate] }, async function (request, reply) {
+    const { name, schema } = request.body || {}
+    const result = await formService.createFormTypeAndSchema(name, schema, fastify.db)
+    reply.code(201)
+    return result
+  })
 }

--- a/onsite-lite-api/services/formService.js
+++ b/onsite-lite-api/services/formService.js
@@ -10,4 +10,8 @@ async function getLatestSchemasByRoles(roles, db) {
   }))
 }
 
-module.exports = { getLatestSchemasByRoles }
+async function createFormTypeAndSchema (name, schema, db) {
+  return formRepository.createFormTypeAndSchema(name, schema, db)
+}
+
+module.exports = { getLatestSchemasByRoles, createFormTypeAndSchema }

--- a/onsite-lite-api/test/routes/forms-create.test.js
+++ b/onsite-lite-api/test/routes/forms-create.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { build } = require('../helper')
+
+const path = '/api/forms'
+
+test('create requires auth', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({ url: path, method: 'POST', payload: {} })
+  assert.equal(res.statusCode, 401)
+})
+
+test('create rejects invalid token', async (t) => {
+  const app = await build(t)
+  const res = await app.inject({
+    url: path,
+    method: 'POST',
+    headers: { authorization: 'Bearer invalid' },
+    payload: {}
+  })
+  assert.equal(res.statusCode, 401)
+})
+
+test('create inserts new form type when none exists', async (t) => {
+  const app = await build(t)
+  const queries = []
+  app.db.query = async (sql, params) => {
+    queries.push({ sql, params })
+    if (sql.includes('SELECT Id FROM FormType')) {
+      return { recordset: [] }
+    }
+    if (sql.includes('INSERT INTO FormType')) {
+      return { recordset: [{ Id: 1 }] }
+    }
+    if (sql.includes('INSERT INTO FormSchema')) {
+      return { recordset: [] }
+    }
+    throw new Error('Unexpected SQL')
+  }
+  const token = app.jwt.sign({ id: 1 })
+  const res = await app.inject({
+    url: path,
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'Test Form', schema: { foo: 'bar' } }
+  })
+  assert.equal(res.statusCode, 201)
+  assert.deepStrictEqual(JSON.parse(res.payload), { formTypeId: 1, version: 1 })
+  assert.equal(queries.length, 3)
+})
+
+test('create adds new version when form type exists', async (t) => {
+  const app = await build(t)
+  app.db.query = async (sql, params) => {
+    if (sql.includes('SELECT Id FROM FormType')) {
+      return { recordset: [{ Id: 1 }] }
+    }
+    if (sql.includes('SELECT MAX(Version)')) {
+      return { recordset: [{ maxVersion: 2 }] }
+    }
+    if (sql.includes('INSERT INTO FormSchema')) {
+      return { recordset: [] }
+    }
+    throw new Error('Unexpected SQL')
+  }
+  const token = app.jwt.sign({ id: 1 })
+  const res = await app.inject({
+    url: path,
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { name: 'Test Form', schema: { foo: 'bar' } }
+  })
+  assert.equal(res.statusCode, 201)
+  assert.deepStrictEqual(JSON.parse(res.payload), { formTypeId: 1, version: 3 })
+})


### PR DESCRIPTION
## Summary
- add POST /api/forms to create new form types and schemas
- support automatic versioning when form type exists
- test creation and versioning logic with authentication guards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dcf7775588328a8f616aa79d6de00