### PR TITLE
Allow production NODE_ENV

### DIFF
--- a/onsite-lite-api/plugins/env.js
+++ b/onsite-lite-api/plugins/env.js
@@ -7,7 +7,8 @@ const schema = {
   type: 'object',
   required: ['NODE_ENV', 'JWT_SECRET', 'DB_HOST', 'DB_USER', 'DB_PASS', 'DB_NAME'],
   properties: {
-    NODE_ENV: { type: 'string', enum: ['dev', 'qa', 'uat', 'staging', 'live'] },
+    // Allow the default "production" value used by many hosting providers
+    NODE_ENV: { type: 'string', enum: ['dev', 'qa', 'uat', 'staging', 'live', 'production'] },
     JWT_SECRET: { type: 'string' },
     DB_HOST: { type: 'string' },
     DB_USER: { type: 'string' },

--- a/onsite-lite-api/test/routes/forms-structure.test.js
+++ b/onsite-lite-api/test/routes/forms-structure.test.js
@@ -4,7 +4,8 @@ const { test } = require('node:test')
 const assert = require('node:assert')
 const { build } = require('../helper')
 
-const path = '/api/forms/structure'
+// Route path updated to match current implementation in routes/api/forms.js
+const path = '/api/FormTemplates'
 
 test('structure requires auth', async (t) => {
   const app = await build(t)


### PR DESCRIPTION
## Summary
- accept `NODE_ENV=production` in environment plugin so apps can start in AWS Elastic Beanstalk
- update forms route tests to use correct path

## Testing
- `NODE_ENV=dev JWT_SECRET=test DB_HOST=localhost DB_USER=user DB_PASS=pass DB_NAME=db SKIP_DB=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e3d7b2b148328abafe246503846e9