### PR TITLE
feat: add .NET API implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
+# .NET build artifacts
+**/bin/
+**/obj/
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # onsite-lite-api
 
-This project provides a Fastify based API with support for MS SQL Server
-connections using the `mssql` package.
+This repository now hosts a sample ASP.NET Core Web API that connects to a
+SQL Server database using `Microsoft.Data.SqlClient`.
 
-Environment credentials for the database are loaded from `.env.<environment>` files in the project root. Create files for `dev`, `qa`, `uat`, `staging` and `live` with variables `DB_HOST`, `DB_USER`, `DB_PASS` and `DB_NAME`.
+## Running the API
+
+The .NET project lives in `dotnet-api`:
+
+```
+cd dotnet-api
+dotnet run
+```
+
+The connection string is built from the following environment variables:
+
+- `DB_HOST`
+- `DB_USER`
+- `DB_PASS`
+- `DB_NAME`
+
+## Endpoints
+
+- `GET /` – returns a simple health object.
+- `GET /form-schemas?roles=role1,role2` – latest schemas for the provided roles.
+- `POST /form-schemas/{name}` – creates a new form type and schema.

--- a/dotnet-api/Db.cs
+++ b/dotnet-api/Db.cs
@@ -1,0 +1,37 @@
+using Microsoft.Data.SqlClient;
+using System.Data;
+
+public static class Db
+{
+    private static SqlConnection? _connection;
+
+    public static async Task InitAsync(IConfiguration configuration)
+    {
+        var dbHost = configuration["DB_HOST"];
+        var dbUser = configuration["DB_USER"];
+        var dbPass = configuration["DB_PASS"];
+        var dbName = configuration["DB_NAME"];
+
+        var masterConnectionString = $"Server={dbHost};Database=master;User Id={dbUser};Password={dbPass};TrustServerCertificate=True";
+        using var master = new SqlConnection(masterConnectionString);
+        await master.OpenAsync();
+
+        var createCmd = master.CreateCommand();
+        createCmd.CommandText = "IF DB_ID(@db) IS NULL BEGIN EXEC('CREATE DATABASE [' + @db + ']') END";
+        createCmd.Parameters.Add(new SqlParameter("@db", dbName));
+        await createCmd.ExecuteNonQueryAsync();
+
+        var connectionString = $"Server={dbHost};Database={dbName};User Id={dbUser};Password={dbPass};TrustServerCertificate=True";
+        _connection = new SqlConnection(connectionString);
+        await _connection.OpenAsync();
+    }
+
+    public static SqlConnection GetConnection()
+    {
+        if (_connection == null)
+        {
+            throw new InvalidOperationException("Database not initialized");
+        }
+        return _connection;
+    }
+}

--- a/dotnet-api/Program.cs
+++ b/dotnet-api/Program.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using DotNetApi.Repositories;
+using DotNetApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+await Db.InitAsync(builder.Configuration);
+builder.Services.AddSingleton(new FormRepository(Db.GetConnection()));
+builder.Services.AddSingleton<FormService>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapGet("/", () => Results.Json(new { root = true }));
+
+app.MapGet("/form-schemas", async (string roles, FormService service) =>
+{
+    var roleList = roles.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    var schemas = await service.GetLatestSchemasByRolesAsync(roleList);
+    return Results.Json(schemas);
+});
+
+app.MapPost("/form-schemas/{name}", async (string name, JsonElement schema, FormService service) =>
+{
+    var result = await service.CreateFormTypeAndSchemaAsync(name, schema);
+    return Results.Json(result);
+});
+
+app.Run();

--- a/dotnet-api/Properties/launchSettings.json
+++ b/dotnet-api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:43137",
+      "sslPort": 44374
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5011",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7297;http://localhost:5011",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/dotnet-api/Repositories/FormRepository.cs
+++ b/dotnet-api/Repositories/FormRepository.cs
@@ -1,0 +1,96 @@
+using Microsoft.Data.SqlClient;
+using System.Text.Json;
+
+namespace DotNetApi.Repositories
+{
+    public record FormSchemaRecord(int FormTypeId, string Name, string SchemaJson, int Version);
+
+    public class FormRepository
+    {
+        private readonly SqlConnection _db;
+
+        public FormRepository(SqlConnection db)
+        {
+            _db = db;
+        }
+
+        public async Task<List<FormSchemaRecord>> GetLatestSchemasByRolesAsync(IEnumerable<string> roles)
+        {
+            var list = roles?.ToList() ?? new List<string>();
+            if (list.Count == 0) return new List<FormSchemaRecord>();
+
+            var parameters = new List<SqlParameter>();
+            var placeholders = new List<string>();
+            for (int i = 0; i < list.Count; i++)
+            {
+                var name = $"@role{i}";
+                placeholders.Add(name);
+                parameters.Add(new SqlParameter(name, list[i]));
+            }
+
+            var sql = $@"SELECT ft.Id AS FormTypeId,
+                                ft.Name AS Name,
+                                fs.SchemaJson AS SchemaJson,
+                                fs.Version AS Version
+                         FROM FormType ft
+                         JOIN FormSchema fs ON fs.FormTypeId = ft.Id
+                         WHERE ft.Name IN ({string.Join(", ", placeholders)})
+                           AND fs.Version = (SELECT MAX(Version) FROM FormSchema WHERE FormTypeId = ft.Id)";
+
+            using var cmd = _db.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.Parameters.AddRange(parameters.ToArray());
+
+            var result = new List<FormSchemaRecord>();
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                result.Add(new FormSchemaRecord(
+                    reader.GetInt32(reader.GetOrdinal("FormTypeId")),
+                    reader.GetString(reader.GetOrdinal("Name")),
+                    reader.GetString(reader.GetOrdinal("SchemaJson")),
+                    reader.GetInt32(reader.GetOrdinal("Version"))
+                ));
+            }
+            return result;
+        }
+
+        public async Task<(int formTypeId, int version)> CreateFormTypeAndSchemaAsync(string name, object schema)
+        {
+            using var checkCmd = _db.CreateCommand();
+            checkCmd.CommandText = "SELECT Id FROM FormType WHERE Name = @name";
+            checkCmd.Parameters.Add(new SqlParameter("@name", name));
+            var existing = await checkCmd.ExecuteScalarAsync();
+
+            int formTypeId;
+            int version;
+
+            if (existing == null)
+            {
+                using var insertType = _db.CreateCommand();
+                insertType.CommandText = "INSERT INTO FormType (Name) OUTPUT INSERTED.Id VALUES (@name)";
+                insertType.Parameters.Add(new SqlParameter("@name", name));
+                formTypeId = Convert.ToInt32(await insertType.ExecuteScalarAsync());
+                version = 1;
+            }
+            else
+            {
+                formTypeId = Convert.ToInt32(existing);
+                using var versionCmd = _db.CreateCommand();
+                versionCmd.CommandText = "SELECT ISNULL(MAX(Version),0) FROM FormSchema WHERE FormTypeId = @formTypeId";
+                versionCmd.Parameters.Add(new SqlParameter("@formTypeId", formTypeId));
+                var maxVersion = Convert.ToInt32(await versionCmd.ExecuteScalarAsync());
+                version = maxVersion + 1;
+            }
+
+            using var insertSchema = _db.CreateCommand();
+            insertSchema.CommandText = "INSERT INTO FormSchema (FormTypeId, SchemaJson, Version) VALUES (@formTypeId, @schemaJson, @version)";
+            insertSchema.Parameters.Add(new SqlParameter("@formTypeId", formTypeId));
+            insertSchema.Parameters.Add(new SqlParameter("@schemaJson", JsonSerializer.Serialize(schema)));
+            insertSchema.Parameters.Add(new SqlParameter("@version", version));
+            await insertSchema.ExecuteNonQueryAsync();
+
+            return (formTypeId, version);
+        }
+    }
+}

--- a/dotnet-api/Services/FormService.cs
+++ b/dotnet-api/Services/FormService.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using DotNetApi.Repositories;
+
+namespace DotNetApi.Services
+{
+    public class FormService
+    {
+        private readonly FormRepository _repository;
+
+        public FormService(FormRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<IEnumerable<FormSchemaDto>> GetLatestSchemasByRolesAsync(IEnumerable<string> roles)
+        {
+            var records = await _repository.GetLatestSchemasByRolesAsync(roles);
+            return records.Select(r => new FormSchemaDto
+            {
+                FormTypeId = r.FormTypeId,
+                Name = r.Name,
+                Schema = JsonDocument.Parse(r.SchemaJson).RootElement,
+                Version = r.Version
+            });
+        }
+
+        public Task<(int formTypeId, int version)> CreateFormTypeAndSchemaAsync(string name, object schema)
+        {
+            return _repository.CreateFormTypeAndSchemaAsync(name, schema);
+        }
+    }
+
+    public class FormSchemaDto
+    {
+        public int FormTypeId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public JsonElement Schema { get; set; }
+        public int Version { get; set; }
+    }
+}

--- a/dotnet-api/appsettings.Development.json
+++ b/dotnet-api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/dotnet-api/appsettings.json
+++ b/dotnet-api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/dotnet-api/dotnet-api.csproj
+++ b/dotnet-api/dotnet-api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>dotnet_api</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet-api/dotnet-api.http
+++ b/dotnet-api/dotnet-api.http
@@ -1,0 +1,6 @@
+@dotnet_api_HostAddress = http://localhost:5011
+
+GET {{dotnet_api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###


### PR DESCRIPTION
## Summary
- add ASP.NET Core Web API project with SQL Server connectivity
- implement form schema repository and service
- document how to run the new .NET API

## Testing
- `dotnet build dotnet-api`


------
https://chatgpt.com/codex/tasks/task_e_688e3ddeb318832893afe010cee38d70